### PR TITLE
サイト所有者確認時にシステムエラーとなる場合があるのを修正

### DIFF
--- a/Service/SiteKitClientFactory.php
+++ b/Service/SiteKitClientFactory.php
@@ -58,11 +58,14 @@ class SiteKitClientFactory
             $router->generate('site_kit42_admin_config', [], UrlGeneratorInterface::ABSOLUTE_URL)
         );
 
-        /** @var Member $Member */
-        $Member = $tokenStorage->getToken()->getUser();
-        if ($Member instanceof Member && !is_null($Member->getIdToken())) {
-            $client->setAccessToken($Member->getIdToken()->getIdToken());
-            $client->setTokenCallback([$factory, 'updateAccessToken']);
+        $Token = $tokenStorage->getToken();
+        if ($Token !== null) {
+            /** @var Member $Member */
+            $Member = $Token->getUser();
+            if ($Member instanceof Member && !is_null($Member->getIdToken())) {
+                $client->setAccessToken($Member->getIdToken()->getIdToken());
+                $client->setTokenCallback([$factory, 'updateAccessToken']);
+            }
         }
 
         return $client;


### PR DESCRIPTION
GoogleBot が siteverification.html をクロールした際に Google_Site_Kit_Proxy_Client が動作してしまい `Call to a member function getUser() on null` となるのを修正