### PR TITLE
Google API から rows が返却されずシステムエラーになる場合があるのを修正

### DIFF
--- a/Controller/Admin/DashboardController.php
+++ b/Controller/Admin/DashboardController.php
@@ -50,6 +50,9 @@ class DashboardController extends AbstractController
         $jsonDate = $this->getJsonFromGoogleSearchData('date', null);
 
         $arrayResponse = json_decode($jsonDate, true);
+        if (!array_key_exists('rows', $arrayResponse)) {
+            $arrayResponse['rows'] = [];
+        }
 
         $arrayDate = array_map(function ($row) {
             $array[] = $row['keys'][0];
@@ -90,6 +93,9 @@ class DashboardController extends AbstractController
     public function formatJson($responseBody)
     {
         $arrayResponse = json_decode($responseBody, true);
+        if (!array_key_exists('rows', $arrayResponse)) {
+            $arrayResponse['rows'] = [];
+        }
 
         $arrayResponse['rows'] = array_map(function ($row) {
             $row['ctr'] = sprintf('%.2f', round($row['ctr'], 2));


### PR DESCRIPTION
以下のように、Google API のレスポンスに rows が含まれない場合がある

```
{
  responseAggregationType: 'byProperty'
}
```


see https://github.com/googleapis/google-api-nodejs-client/issues/677#issuecomment-269555994